### PR TITLE
Fixed mnemonic warning

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -15,7 +15,7 @@
                     {
                         "caption": "Restore color scheme",
                         "command": "color_highlight_restore",
-                        "mnemonic": "S"
+                        "mnemonic": "s"
                     },
                     {
                         "caption": "Reset Text Marker",


### PR DESCRIPTION
Changing the mnemonic to lowercase removes the console warning "mnemonic S not found in menu caption Restore color scheme".